### PR TITLE
#38 Add support for Atomikos using non-XA JDBC implementations

### DIFF
--- a/flexy-atomikos/src/main/java/com/vladmihalcea/flexypool/adaptor/AtomikosPoolAdapter.java
+++ b/flexy-atomikos/src/main/java/com/vladmihalcea/flexypool/adaptor/AtomikosPoolAdapter.java
@@ -1,29 +1,29 @@
 package com.vladmihalcea.flexypool.adaptor;
 
-import com.atomikos.jdbc.AtomikosDataSourceBean;
+import com.atomikos.jdbc.AbstractDataSourceBean;
 import com.atomikos.jdbc.AtomikosSQLException;
 import com.vladmihalcea.flexypool.common.ConfigurationProperties;
 import com.vladmihalcea.flexypool.metric.Metrics;
 
 /**
  * <code>AtomikosPoolAdapter</code> extends {@link AbstractPoolAdapter} and it adapts the required API to
- * communicate with the {@link AtomikosDataSourceBean}
+ * communicate with the {@link AbstractDataSourceBean Atomikos DataSourceBean}
  *
  * @author Vlad Mihalcea
  * @since 1.2.1
  */
-public class AtomikosPoolAdapter extends AbstractPoolAdapter<AtomikosDataSourceBean> {
+public class AtomikosPoolAdapter extends AbstractPoolAdapter<AbstractDataSourceBean> {
 
     public static final String ACQUIRE_TIMEOUT_MESSAGE = "Connection pool exhausted - try increasing 'maxPoolSize' and/or 'borrowConnectionTimeout' on the DataSourceBean.";
 
     /**
      * Singleton factory object reference
      */
-    public static final PoolAdapterFactory<AtomikosDataSourceBean> FACTORY = new PoolAdapterFactory<AtomikosDataSourceBean>() {
+    public static final PoolAdapterFactory<AbstractDataSourceBean> FACTORY = new PoolAdapterFactory<AbstractDataSourceBean>() {
 
         @Override
-        public PoolAdapter<AtomikosDataSourceBean> newInstance(
-                ConfigurationProperties<AtomikosDataSourceBean, Metrics, PoolAdapter<AtomikosDataSourceBean>> configurationProperties) {
+        public PoolAdapter<AbstractDataSourceBean> newInstance(
+                ConfigurationProperties<AbstractDataSourceBean, Metrics, PoolAdapter<AbstractDataSourceBean>> configurationProperties) {
             return new AtomikosPoolAdapter(configurationProperties);
         }
     };
@@ -31,7 +31,7 @@ public class AtomikosPoolAdapter extends AbstractPoolAdapter<AtomikosDataSourceB
     /**
      * Init constructor
      */
-    public AtomikosPoolAdapter(ConfigurationProperties<AtomikosDataSourceBean, Metrics, PoolAdapter<AtomikosDataSourceBean>> configurationProperties) {
+    public AtomikosPoolAdapter(ConfigurationProperties<AbstractDataSourceBean, Metrics, PoolAdapter<AbstractDataSourceBean>> configurationProperties) {
         super(configurationProperties);
     }
 

--- a/flexy-atomikos/src/test/java/com/vladmihalcea/flexypool/config/FlexyPoolConfiguration.java
+++ b/flexy-atomikos/src/test/java/com/vladmihalcea/flexypool/config/FlexyPoolConfiguration.java
@@ -1,5 +1,6 @@
 package com.vladmihalcea.flexypool.config;
 
+import com.atomikos.jdbc.AbstractDataSourceBean;
 import com.atomikos.jdbc.AtomikosDataSourceBean;
 import com.vladmihalcea.flexypool.FlexyPoolDataSource;
 import com.vladmihalcea.flexypool.adaptor.AtomikosPoolAdapter;
@@ -28,8 +29,8 @@ public class FlexyPoolConfiguration {
     private String uniqueId;
 
     @Bean
-    public Configuration<AtomikosDataSourceBean> configuration() {
-        return new Configuration.Builder<AtomikosDataSourceBean>(
+    public Configuration<AbstractDataSourceBean> configuration() {
+        return new Configuration.Builder<AbstractDataSourceBean>(
                 uniqueId,
                 poolingDataSource,
                 AtomikosPoolAdapter.FACTORY
@@ -41,8 +42,8 @@ public class FlexyPoolConfiguration {
 
     @Bean(initMethod = "start", destroyMethod = "stop")
     public FlexyPoolDataSource dataSource() {
-        Configuration<AtomikosDataSourceBean> configuration = configuration();
-        return new FlexyPoolDataSource<AtomikosDataSourceBean>(configuration,
+        Configuration<AbstractDataSourceBean> configuration = configuration();
+        return new FlexyPoolDataSource<AbstractDataSourceBean>(configuration,
                 new IncrementPoolOnTimeoutConnectionAcquiringStrategy.Factory(5),
                 new RetryConnectionAcquiringStrategy.Factory(2)
         );


### PR DESCRIPTION
The AtomikosPoolAdapter was unnecessarily tied to the XA-specific
AtomikosDataSourceBean instead of its abstract base class.

This change enables support for the AtomikosNonXADataSourceBean.