### PR TITLE
Closeable data source

### DIFF
--- a/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/FlexyPoolDataSource.java
+++ b/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/FlexyPoolDataSource.java
@@ -25,6 +25,9 @@ import com.vladmihalcea.flexypool.strategy.ConnectionAcquiringStrategyFactory;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
+
+import java.io.Closeable;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -66,7 +69,7 @@ import java.util.logging.Logger;
  * @author Vlad Mihalcea
  * @since 1.0
  */
-public class FlexyPoolDataSource<T extends DataSource> implements DataSource, LifeCycleCallback, ConnectionPoolCallback {
+public class FlexyPoolDataSource<T extends DataSource> implements DataSource, LifeCycleCallback, ConnectionPoolCallback, Closeable {
 
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(FlexyPoolDataSource.class);
 
@@ -422,5 +425,13 @@ public class FlexyPoolDataSource<T extends DataSource> implements DataSource, Li
     public void stop() {
         metrics.stop();
     }
+
+	@Override
+	public void close() throws IOException {
+        metrics.stop();
+        if (targetDataSource instanceof Closeable) {
+        	((Closeable)targetDataSource).close();
+        }
+	}
 
 }

--- a/flexy-pool-core/src/test/java/com/vladmihalcea/flexypool/FlexyPoolDataSourceTest.java
+++ b/flexy-pool-core/src/test/java/com/vladmihalcea/flexypool/FlexyPoolDataSourceTest.java
@@ -18,6 +18,8 @@ import com.vladmihalcea.flexypool.common.ConfigurationProperties;
 import com.vladmihalcea.flexypool.util.JndiTestUtils;
 import com.vladmihalcea.flexypool.util.MockDataSource;
 import com.vladmihalcea.flexypool.util.PropertiesTestUtils;
+
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -35,6 +37,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
@@ -342,5 +345,23 @@ public class FlexyPoolDataSourceTest {
         Connection connection = Mockito.mock(Connection.class);
         when(dataSource.getConnection()).thenReturn(connection);
         flexyPoolDataSource.getConnection().close();
+    }
+    
+    @Test
+    public void testNonCloseableDataSource() throws IOException {
+    	// test that we do not fail even when targetDataSource is not closeable
+    	assertThat(dataSource, CoreMatchers.not(instanceOf(java.io.Closeable.class)));
+    	flexyPoolDataSource.close();
+    }
+    
+    @Test
+    public void testCloseableDataSource() throws IOException {
+    	DataSource ds = mock(DataSource.class, withSettings().extraInterfaces(java.io.Closeable.class));
+    	
+    	FlexyPoolDataSource<DataSource> fpds = new FlexyPoolDataSource<DataSource>(ds);
+    	fpds.close();
+    	
+    	verify((java.io.Closeable)ds, times(1)).close();
+    	
     }
 }


### PR DESCRIPTION
With this code FlexyPoolDataSource implements Closeable and delegates close call to targetDataSource if it also implements Closeable interface.
This allows cleanup for example HikariDataSource pools when closing dataSource.