### PR TITLE
Support for multiple JNDI datasources in JEE.

### DIFF
--- a/flexy-java-ee/src/main/java/com/vladmihalcea/flexypool/adaptor/FlexyPoolHibernateConnectionProvider.java
+++ b/flexy-java-ee/src/main/java/com/vladmihalcea/flexypool/adaptor/FlexyPoolHibernateConnectionProvider.java
@@ -35,7 +35,7 @@ public class FlexyPoolHibernateConnectionProvider extends DatasourceConnectionPr
     public void configure(Map props) {
         super.configure(props);
         LOGGER.debug("Hibernate switched to using FlexyPoolDataSource");
-        flexyPoolDataSource = new FlexyPoolDataSource<DataSource>(getDataSource());
+        flexyPoolDataSource = new FlexyPoolDataSource<DataSource>(getDataSource(), props);
     }
 
     /**

--- a/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/config/PropertyLoader.java
+++ b/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/config/PropertyLoader.java
@@ -71,6 +71,7 @@ public class PropertyLoader {
     }
 
     private final Properties properties = new Properties();
+    private Map globalProperties = null;
 
     public PropertyLoader() {
         load();
@@ -138,7 +139,7 @@ public class PropertyLoader {
      * @return {@link DataSource} unique name
      */
     public String getUniqueName() {
-        return properties.getProperty(PropertyKey.DATA_SOURCE_UNIQUE_NAME.getKey());
+        return getProperty(PropertyKey.DATA_SOURCE_UNIQUE_NAME.getKey());
     }
 
     /**
@@ -291,7 +292,7 @@ public class PropertyLoader {
      */
     private <T> T instantiateClass(PropertyKey propertyKey) {
         T object = null;
-        String property = properties.getProperty(propertyKey.getKey());
+        String property = getProperty(propertyKey.getKey());
         if (property != null) {
             try {
                 Class<T> clazz = ClassLoaderUtils.loadClass(property);
@@ -316,7 +317,7 @@ public class PropertyLoader {
      */
     private Integer integerProperty(PropertyKey propertyKey) {
         Integer value = null;
-        String property = properties.getProperty(propertyKey.getKey());
+        String property = getProperty(propertyKey.getKey());
         if (property != null) {
             value = Integer.valueOf(property);
         }
@@ -331,7 +332,7 @@ public class PropertyLoader {
      */
     private Long longProperty(PropertyKey propertyKey) {
         Long value = null;
-        String property = properties.getProperty(propertyKey.getKey());
+        String property = getProperty(propertyKey.getKey());
         if (property != null) {
             value = Long.valueOf(property);
         }
@@ -346,7 +347,7 @@ public class PropertyLoader {
      */
     private Boolean booleanProperty(PropertyKey propertyKey) {
         Boolean value = null;
-        String property = properties.getProperty(propertyKey.getKey());
+        String property = getProperty(propertyKey.getKey());
         if (property != null) {
             value = Boolean.valueOf(property);
         }
@@ -362,12 +363,25 @@ public class PropertyLoader {
      */
     @SuppressWarnings("unchecked")
     private <T> T jndiLookup(PropertyKey propertyKey) {
-        String property = properties.getProperty(propertyKey.getKey());
+        String property = getProperty(propertyKey.getKey());
         if (property != null) {
             return isJndiLazyLookup() ?
                     (T) LazyJndiResolver.newInstance(property, DataSource.class) :
                     (T) JndiUtils.lookup(property);
         }
         return null;
+    }
+
+    public void setGlobalProperties(Map props) {
+        this.globalProperties = props;
+    }
+
+    private String getProperty(String key) {
+        if(null != this.globalProperties) {
+            if(this.globalProperties.containsKey(key)) {
+                return (String) this.globalProperties.get(key);
+            }
+        }
+        return properties.getProperty(key);
     }
 }


### PR DESCRIPTION
Patch to allow the specification of flexy pool configuration properties in JPA persistence.xml file. flexy-pool.properties is still used a a fallback, but the values specified in the persistence unit declaration, such as <property name="flexy.pool.data.source.unique.name" value="sen-ds"/>, are preferred.

This allow to use FlexyPool to monitor multiple JNDI datasource in JEE.