### PR TITLE
Fix the Include uniqueName in the metric names #60 issue

### DIFF
--- a/flexy-micrometer-metrics/src/main/java/com/vladmihalcea/flexypool/metric/micrometer/MicrometerMetrics.java
+++ b/flexy-micrometer-metrics/src/main/java/com/vladmihalcea/flexypool/metric/micrometer/MicrometerMetrics.java
@@ -5,9 +5,6 @@ import com.vladmihalcea.flexypool.metric.Histogram;
 import com.vladmihalcea.flexypool.metric.Timer;
 import com.vladmihalcea.flexypool.common.ConfigurationProperties;
 
-import java.util.Collection;
-import java.util.LinkedHashSet;
-
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
@@ -18,13 +15,15 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
  * @since 2.1.0
  */
 public class MicrometerMetrics extends AbstractMetrics {
-    
+    private static final String METRIC_PREFIX = "flexypool.";
+    private static final String POOLNAME_TAG = "poolname";
+
     public static final MetricsFactory FACTORY = new MetricsFactory() {
         @Override public Metrics newInstance(ConfigurationProperties configurationProperties) {
             return new MicrometerMetrics(configurationProperties, io.micrometer.core.instrument.Metrics.globalRegistry);
         }
     };
-    
+
     private final MeterRegistry metricRegistry;
 
     /**
@@ -51,7 +50,8 @@ public class MicrometerMetrics extends AbstractMetrics {
      */
     @Override
     public Histogram histogram(String name) {
-        return new MicrometerHistogram(metricRegistry.summary(name));
+        return new MicrometerHistogram(metricRegistry.summary("flexypool." + name,
+                "poolname", getConfigurationProperties().getUniqueName()));
     }
 
     /**
@@ -59,16 +59,17 @@ public class MicrometerMetrics extends AbstractMetrics {
      */
     @Override
     public Timer timer(String name) {
-        return new MicrometerTimer(metricRegistry.timer(name));
+        return new MicrometerTimer(metricRegistry.timer(METRIC_PREFIX + name,
+                POOLNAME_TAG, getConfigurationProperties().getUniqueName()));
     }
-    
+
     @Override
     public void start() {
-    
+
     }
-    
+
     @Override
     public void stop() {
-    
+
     }
 }

--- a/flexy-micrometer-metrics/src/test/java/com/vladmihalcea/flexypool/metric/micrometer/MicrometerMetricsTest.java
+++ b/flexy-micrometer-metrics/src/test/java/com/vladmihalcea/flexypool/metric/micrometer/MicrometerMetricsTest.java
@@ -4,17 +4,27 @@ import com.vladmihalcea.flexypool.common.ConfigurationProperties;
 import com.vladmihalcea.flexypool.metric.Histogram;
 import com.vladmihalcea.flexypool.metric.Metrics;
 import com.vladmihalcea.flexypool.metric.Timer;
+import com.vladmihalcea.flexypool.strategy.DefaultNamingStrategy;
+import com.vladmihalcea.flexypool.strategy.UniquenameNamingStrategy;
 import com.vladmihalcea.flexypool.util.ReflectionUtils;
+import io.micrometer.core.instrument.Tag;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 import io.micrometer.core.instrument.MeterRegistry;
+
+import java.util.Iterator;
 
 /**
  * MicrometerMetricsTest - MicrometerMetrics Test
@@ -29,6 +39,12 @@ public class MicrometerMetricsTest {
     @Mock
     private MeterRegistry metricRegistry;
 
+    @Captor
+    private ArgumentCaptor<String> nameCaptor;
+
+    @Captor
+    private ArgumentCaptor<Iterable<Tag>> tagCaptor;
+
     @Before
     public void before() {
         MockitoAnnotations.initMocks(this);
@@ -42,6 +58,7 @@ public class MicrometerMetricsTest {
 
     @Test
     public void testHistogram() {
+        when(configurationProperties.getMetricNamingStrategy()).thenReturn(new DefaultNamingStrategy());
         MicrometerMetrics micrometerMetrics = new MicrometerMetrics(configurationProperties);
         assertSame(configurationProperties, micrometerMetrics.getConfigurationProperties());
         Histogram histogram = micrometerMetrics.histogram("histo");
@@ -49,16 +66,74 @@ public class MicrometerMetricsTest {
     }
 
     @Test
+    public void testHistogramDefaultNamingStrategy() {
+        when(configurationProperties.getMetricNamingStrategy()).thenReturn(new DefaultNamingStrategy());
+        MicrometerMetrics micrometerMetrics = new MicrometerMetrics(configurationProperties, metricRegistry);
+        Histogram histogram = micrometerMetrics.histogram("histo");
+        assertNotNull(histogram);
+        verify(metricRegistry).summary(nameCaptor.capture(), tagCaptor.capture());
+        assertEquals("histo", nameCaptor.getValue());
+        assertFalse(tagCaptor.getValue().iterator().hasNext());
+    }
+
+    @Test
+    public void testHistogramUniquenameNamingStrategy() {
+        when(configurationProperties.getUniqueName()).thenReturn("uniqueName");
+        when(configurationProperties.getMetricNamingStrategy()).thenReturn(new UniquenameNamingStrategy());
+        MicrometerMetrics micrometerMetrics = new MicrometerMetrics(configurationProperties, metricRegistry);
+        Histogram histogram = micrometerMetrics.histogram("histo");
+        assertNotNull(histogram);
+        verify(metricRegistry).summary(nameCaptor.capture(), tagCaptor.capture());
+        assertEquals("flexypool_histo", nameCaptor.getValue());
+        Iterator<Tag> tags = tagCaptor.getValue().iterator();
+        assertTrue(tags.hasNext());
+        Tag tag = tags.next();
+        assertEquals("poolname", tag.getKey());
+        assertEquals("uniqueName", tag.getValue());
+        assertFalse(tags.hasNext());
+    }
+
+    @Test
     public void testTimer() {
+        when(configurationProperties.getMetricNamingStrategy()).thenReturn(new DefaultNamingStrategy());
         MicrometerMetrics micrometerMetrics = new MicrometerMetrics(configurationProperties);
         Timer timer = micrometerMetrics.timer("timer");
         assertNotNull(timer);
     }
 
     @Test
+    public void testTimerDefaultNamingStrategy() {
+        when(configurationProperties.getMetricNamingStrategy()).thenReturn(new DefaultNamingStrategy());
+        MicrometerMetrics micrometerMetrics = new MicrometerMetrics(configurationProperties, metricRegistry);
+        Timer timer = micrometerMetrics.timer("timer");
+        assertNotNull(timer);
+        verify(metricRegistry).timer(nameCaptor.capture(), tagCaptor.capture());
+        assertEquals("timer", nameCaptor.getValue());
+        assertFalse(tagCaptor.getValue().iterator().hasNext());
+    }
+
+    @Test
+    public void testTimerUniquenameNamingStrategy() {
+        when(configurationProperties.getUniqueName()).thenReturn("uniqueName");
+        when(configurationProperties.getMetricNamingStrategy()).thenReturn(new UniquenameNamingStrategy());
+        MicrometerMetrics micrometerMetrics = new MicrometerMetrics(configurationProperties, metricRegistry);
+        Timer timer = micrometerMetrics.timer("timer");
+        assertNotNull(timer);
+        verify(metricRegistry).timer(nameCaptor.capture(), tagCaptor.capture());
+        assertEquals("flexypool_timer", nameCaptor.getValue());
+        Iterator<Tag> tags = tagCaptor.getValue().iterator();
+        assertTrue(tags.hasNext());
+        Tag tag = tags.next();
+        assertEquals("poolname", tag.getKey());
+        assertEquals("uniqueName", tag.getValue());
+        assertFalse(tags.hasNext());
+    }
+
+    @Test
     public void testStartStopUsingDefaultConfiguration() {
         when(configurationProperties.isJmxEnabled()).thenReturn(true);
         when(configurationProperties.getMetricLogReporterMillis()).thenReturn(5L);
+        when(configurationProperties.getMetricNamingStrategy()).thenReturn(new DefaultNamingStrategy());
         testStartStop(configurationProperties);
     }
 
@@ -66,6 +141,7 @@ public class MicrometerMetricsTest {
     public void testStartStopUsingNoJmx() {
         when(configurationProperties.isJmxEnabled()).thenReturn(false);
         when(configurationProperties.getMetricLogReporterMillis()).thenReturn(5L);
+        when(configurationProperties.getMetricNamingStrategy()).thenReturn(new DefaultNamingStrategy());
         testStartStop(configurationProperties);
     }
 

--- a/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/common/ConfigurationProperties.java
+++ b/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/common/ConfigurationProperties.java
@@ -2,6 +2,7 @@ package com.vladmihalcea.flexypool.common;
 
 import com.vladmihalcea.flexypool.connection.ConnectionProxyFactory;
 import com.vladmihalcea.flexypool.event.EventPublisher;
+import com.vladmihalcea.flexypool.strategy.MetricNamingStrategy;
 
 import javax.sql.DataSource;
 
@@ -23,6 +24,8 @@ public abstract class ConfigurationProperties<T extends DataSource, M, P> {
     private boolean jmxAutoStart;
 
     private long metricLogReporterMillis;
+
+    private MetricNamingStrategy metricNamingStrategy;
 
     private long connectionAcquireTimeThresholdMillis = Long.MAX_VALUE;
 
@@ -103,6 +106,24 @@ public abstract class ConfigurationProperties<T extends DataSource, M, P> {
      */
     protected void setMetricLogReporterMillis(long metricLogReporterMillis) {
         this.metricLogReporterMillis = metricLogReporterMillis;
+    }
+
+    /**
+     * get metric naming strategy
+     *
+     * @return metric naming strategy
+     */
+    public MetricNamingStrategy getMetricNamingStrategy() {
+        return metricNamingStrategy;
+    }
+
+    /**
+     * Set metric naming strategy
+     *
+     * @param metricNamingStrategy metric naming strategy
+     */
+    public void setMetricNamingStrategy(MetricNamingStrategy metricNamingStrategy) {
+        this.metricNamingStrategy = metricNamingStrategy;
     }
 
     /**

--- a/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/config/Configuration.java
+++ b/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/config/Configuration.java
@@ -10,6 +10,8 @@ import com.vladmihalcea.flexypool.event.EventPublisher;
 import com.vladmihalcea.flexypool.metric.Metrics;
 import com.vladmihalcea.flexypool.metric.MetricsFactory;
 import com.vladmihalcea.flexypool.metric.MetricsFactoryResolver;
+import com.vladmihalcea.flexypool.strategy.DefaultNamingStrategy;
+import com.vladmihalcea.flexypool.strategy.MetricNamingStrategy;
 
 import javax.sql.DataSource;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +41,7 @@ public final class Configuration<T extends DataSource> extends ConfigurationProp
         private boolean jmxEnabled = true;
         private boolean jmxAutoStart = false;
         private long metricLogReporterMillis = DEFAULT_METRIC_LOG_REPORTER_MILLIS;
+        private MetricNamingStrategy metricNamingStrategy = new DefaultNamingStrategy();
         private EventListenerResolver eventListenerResolver;
         private long connectionAcquireTimeThresholdMillis = Long.MAX_VALUE;
         private long connectionLeaseTimeThresholdMillis = Long.MAX_VALUE;
@@ -112,6 +115,17 @@ public final class Configuration<T extends DataSource> extends ConfigurationProp
         }
 
         /**
+         * Strategy for metric naming
+         *
+         * @param metricNamingStrategy strategy for metric naming
+         * @return this {@link com.vladmihalcea.flexypool.config.Configuration.Builder}
+         */
+        public Builder<T> setMetricNamingUniqueName(MetricNamingStrategy metricNamingStrategy) {
+            this.metricNamingStrategy = metricNamingStrategy;
+            return this;
+        }
+
+        /**
          * Set the event listener resolver
          *
          * @param eventListenerResolver event listener resolver
@@ -159,6 +173,7 @@ public final class Configuration<T extends DataSource> extends ConfigurationProp
             configuration.setJmxEnabled(jmxEnabled);
             configuration.setJmxAutoStart(jmxAutoStart);
             configuration.setMetricLogReporterMillis(metricLogReporterMillis);
+            configuration.setMetricNamingStrategy(metricNamingStrategy);
             configuration.setConnectionAcquireTimeThresholdMillis(connectionAcquireTimeThresholdMillis);
             configuration.setConnectionLeaseTimeThresholdMillis(connectionLeaseTimeThresholdMillis);
             if(metricsFactory == null) {

--- a/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/config/PropertyLoader.java
+++ b/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/config/PropertyLoader.java
@@ -7,6 +7,7 @@ import com.vladmihalcea.flexypool.metric.MetricsFactory;
 import com.vladmihalcea.flexypool.strategy.ConnectionAcquiringStrategy;
 import com.vladmihalcea.flexypool.strategy.ConnectionAcquiringStrategyFactory;
 import com.vladmihalcea.flexypool.strategy.ConnectionAcquiringStrategyFactoryResolver;
+import com.vladmihalcea.flexypool.strategy.MetricNamingStrategy;
 import com.vladmihalcea.flexypool.util.ClassLoaderUtils;
 import com.vladmihalcea.flexypool.util.JndiUtils;
 import com.vladmihalcea.flexypool.util.LazyJndiResolver;
@@ -54,6 +55,7 @@ public class PropertyLoader {
         POOL_METRICS_REPORTER_LOG_MILLIS("flexy.pool.metrics.reporter.log.millis"),
         POOL_METRICS_REPORTER_JMX_ENABLE("flexy.pool.metrics.reporter.jmx.enable"),
         POOL_METRICS_REPORTER_JMX_AUTO_START("flexy.pool.metrics.reporter.jmx.auto.start"),
+        POOL_METRICS_NAMING_STRATEGY("flexy.pool.metrics.naming.strategy"),
         POOL_STRATEGIES_FACTORY_RESOLVER("flexy.pool.strategies.factory.resolver"),
         POOL_EVENT_LISTENER_RESOLVER("flexy.pool.event.listener.resolver"),
         POOL_TIME_THRESHOLD_CONNECTION_ACQUIRE("flexy.pool.time.threshold.connection.acquire"),
@@ -235,6 +237,15 @@ public class PropertyLoader {
      */
     public Boolean isJmxAutoStart() {
         return booleanProperty(PropertyKey.POOL_METRICS_REPORTER_JMX_AUTO_START);
+    }
+
+    /**
+     * Get the metric naming strategy
+     *
+     * @return metric naming strategy
+     */
+    public MetricNamingStrategy getMetricNamingStrategy() {
+        return instantiateClass(PropertyKey.POOL_METRICS_NAMING_STRATEGY);
     }
 
     /**

--- a/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/strategy/DefaultNamingStrategy.java
+++ b/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/strategy/DefaultNamingStrategy.java
@@ -1,0 +1,20 @@
+package com.vladmihalcea.flexypool.strategy;
+
+/**
+ * <code>DefaultNamingStrategy</code> implements the {@link MetricNamingStrategy}
+ * keep namings as before
+ *
+ * @author Atle Tokle
+ * @since 2.2.2
+ */
+public class DefaultNamingStrategy implements MetricNamingStrategy {
+    @Override
+    public String getMetricName(String name) {
+        return name;
+    }
+
+    @Override
+    public boolean usePoolUniqueName() {
+        return false;
+    }
+}

--- a/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/strategy/MetricNamingStrategy.java
+++ b/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/strategy/MetricNamingStrategy.java
@@ -1,0 +1,23 @@
+package com.vladmihalcea.flexypool.strategy;
+
+/**
+ * <code>MetricNamingStrategy</code>
+ * defines the metrics naming strategy
+ *
+ * @author Atle Tokle
+ * @since 2.2.2
+ */
+public interface MetricNamingStrategy {
+    /**
+     * Get decorated name for metric
+     * @param name basic name for metric
+     * @return decorated name for metric
+     */
+    String getMetricName(String name);
+
+    /**
+     * Use unique metric for each unique pool name
+     * @return Use unique metric for each unique pool name
+     */
+    boolean usePoolUniqueName();
+}

--- a/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/strategy/UniquenameNamingStrategy.java
+++ b/flexy-pool-core/src/main/java/com/vladmihalcea/flexypool/strategy/UniquenameNamingStrategy.java
@@ -1,0 +1,22 @@
+package com.vladmihalcea.flexypool.strategy;
+
+/**
+ * <code>UniquenameNamingStrategy</code> implements the {@link MetricNamingStrategy}
+ * Unique metrics for each unique pool name. Metrics prefixed
+ *
+ * @author Atle Tokle
+ * @since 2.2.2
+ */
+public class UniquenameNamingStrategy implements MetricNamingStrategy {
+    private static final String METRIC_PREFIX = "flexypool_";
+
+    @Override
+    public String getMetricName(String name) {
+        return METRIC_PREFIX + name;
+    }
+
+    @Override
+    public boolean usePoolUniqueName() {
+        return true;
+    }
+}

--- a/flexy-pool-core/src/test/java/com/vladmihalcea/flexypool/strategy/DefaultNamingStrategyTest.java
+++ b/flexy-pool-core/src/test/java/com/vladmihalcea/flexypool/strategy/DefaultNamingStrategyTest.java
@@ -1,0 +1,16 @@
+package com.vladmihalcea.flexypool.strategy;
+
+import junit.framework.TestCase;
+
+public class DefaultNamingStrategyTest extends TestCase {
+    private MetricNamingStrategy namingStrategy = new DefaultNamingStrategy();
+
+    public void testNameStrategy() {
+        assertEquals("metricName", namingStrategy.getMetricName("metricName"));
+    }
+
+    public void testUseUniqueNames() {
+        assertFalse(namingStrategy.usePoolUniqueName());
+    }
+
+}

--- a/flexy-pool-core/src/test/java/com/vladmihalcea/flexypool/strategy/UniquenameNamingStrategyTest.java
+++ b/flexy-pool-core/src/test/java/com/vladmihalcea/flexypool/strategy/UniquenameNamingStrategyTest.java
@@ -1,0 +1,15 @@
+package com.vladmihalcea.flexypool.strategy;
+
+import junit.framework.TestCase;
+
+public class UniquenameNamingStrategyTest extends TestCase {
+    private MetricNamingStrategy namingStrategy = new UniquenameNamingStrategy();
+
+    public void testNameStrategy() {
+        assertEquals("flexypool_metricName", namingStrategy.getMetricName("metricName"));
+    }
+
+    public void testUseUniqueNames() {
+        assertTrue(namingStrategy.usePoolUniqueName());
+    }
+}


### PR DESCRIPTION
All metrics wil now start with flexypool_ making it easy to see which metrics is made from flexy-pool
All metrics will have a parameter poolname= with the value from the pools uniqueName making it possible to see what pool the metric belongs to.
Example. The metrics:
```
concurrentConnectionRequestsHistogram_count 12.0
concurrentConnectionRequestsHistogram_sum 6.0
```
will with 2 pools with uniqueNames quartzPool and batchPool become
```
flexypool_concurrentConnectionRequestsHistogram_count{poolname="quartzPool",} 6.0
flexypool_concurrentConnectionRequestsHistogram_sum{poolname="quartzPool",} 3.0
flexypool_concurrentConnectionRequestsHistogram_count{poolname="batchPool",} 6.0
flexypool_concurrentConnectionRequestsHistogram_sum{poolname="batchPool",} 3.0
```