### PR TITLE
Run all the tests in multiple forked VM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                	<forkCount>1.5C</forkCount>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -255,6 +258,7 @@
                                 </property>
                             </systemProperties>
                             <argLine>-Xms2512m -Xmx2512m -XX:MaxPermSize=256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -verbose:gc -Xloggc:${project.build.directory}/gc.log</argLine>
+                	<forkCount>1.5C</forkCount>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
